### PR TITLE
Updates dockerfile with expose to document the port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ ADD . /data
 
 VOLUME ["/data"]
 
+EXPOSE 33001
+
 CMD ["/go/bin/allmark", "serve", "/data"]


### PR DESCRIPTION
First place I checked when deploying with docker was the dockerfile as 80 wasn't working, nor was the docker logs command working (may take a look into this in a bit.

The expose in the dockerfile should better self document the needed ports.

#9 