### PR TITLE
fixed dockerfile to work from working dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ MAINTAINER Andreas Koch <andy@allmark.io>
 RUN apt-get update && apt-get install -qy pandoc
 
 # Build
-ADD . /go
+ADD . /go/src/vendor/github.com/andreaskoch/allmark
+WORKDIR /go/src/vendor/github.com/andreaskoch/allmark
 RUN make install
 RUN make crosscompile
 
@@ -15,4 +16,6 @@ ADD . /data
 
 VOLUME ["/data"]
 
-CMD ["/go/bin/allmark", "serve", "/data"]
+EXPOSE 33001
+
+CMD ["bin/files/allmark", "serve", "/data"]


### PR DESCRIPTION
i noticed  after cloning the dockerfile doesn't work properly.  It seem the directories are off if you want to do a ```docker build .```  from the working directory.