### PR TITLE
add go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/andreaskoch/allmark
+
+go 1.19


### PR DESCRIPTION
This is a minimum viable change to enable modern go toolchains to build github.com/andreaskoch/allmark/cli in go module mode. The module is not tidy, and we are relying on ./vendor, but it does build.